### PR TITLE
Update CA.yaml

### DIFF
--- a/data/countries/CA.yaml
+++ b/data/countries/CA.yaml
@@ -64,7 +64,7 @@ holidays:
         name:
           en: Civic Holiday
           fr: Premier lundi d’août
-      monday after 08-31:
+      1st monday in September:
         _name: 05-01
       2nd monday after 10-01:
         name:


### PR DESCRIPTION
Change `monday after 08-31` to `1st monday in September`. Labour Day falls on Monday, September 7, 2020 next year, not on Monday, August 31, 2020 as would be calculated with the `after` verb.